### PR TITLE
Fix bug in direct decorator search that returns past the end of an array

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -82,7 +82,7 @@ export const directDecoratorSearch = (...classes: Class[]): Decorators => {
 		return {};
 
 	if (classDecorators.length === 1)
-		return classDecorators[1];
+		return classDecorators[0];
 
 	return classDecorators.reduce((d1, d2) => mergeDecorators(d1, d2));
 };


### PR DESCRIPTION
I didn't run into this bug myself but found it tracing other stuff.