### PR TITLE
Give init function a default name

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,7 @@ export type Settings = {
 };
 
 export const settings: Settings = {
-	initFunction: null,
+	initFunction: 'init',
 	staticsStrategy: 'copy',
 	prototypeStrategy: 'copy',
 	decoratorInheritance: 'deep',


### PR DESCRIPTION
The timing of `mix` decorators be called depend on file name. So I have no idea how to set a default value for the `settings` in my bootstrap code. To make the settings work, I have to set the `settings` in every single file where I use the `mix` decorator. To workaround this, at least we should have a default value for it, or passing a settings object to the decorator itself.